### PR TITLE
Feature: Add GFM (GitHub Flavored Markdown) format support.

### DIFF
--- a/Sources/TestifySDK/Codable/TestResultGitHubFlavoredMarkdownEncoder.swift
+++ b/Sources/TestifySDK/Codable/TestResultGitHubFlavoredMarkdownEncoder.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public struct TestResultGitHubFlavoredMarkdownEncoder: TestResultEncoder {
+    
+    public init() {
+        
+    }
+    
+    public func encode(_ input: TestSuite) throws -> String {
+        var totalTestsCount = 0
+        var totalTime: Double = 0
+        var totalSucceedCount = 0
+        var totalFailedCount = 0
+        var result = ""
+
+        let suites: [TestSuite] = input.children.reduce([]) { $0 + $1.children }
+        for suite in suites {
+            result += "\n"
+            let name = suite.name
+            let count = suite.cases.count
+            let time = suite.cases.reduce(0) { $0 + $1.duration }
+            let successCount = suite.cases.reduce(0) { $0 + ($1.outcome == .success ? 1 : 0) }
+            let failureCount = suite.cases.reduce(0) { $0 + ($1.outcome == .failure ? 1 : 0) }
+            
+            totalTestsCount += count
+            totalTime += time
+            totalSucceedCount += successCount
+            totalFailedCount += totalFailedCount
+            
+            result += "<details>\n"
+            let suiteResult = count == successCount ? "✅" : "❌"
+            result += "<summary> \(suiteResult) \(name): \(count) tests were completed in \(timeString(time)) with \(successCount) passed, \(failureCount) failed.</summary>\n"
+            
+            for testCase in suite.cases {
+                let name = testCase.testName
+                let testResult = testCase.outcome == .success ? "✅" : "❌"
+                let time = timeString(testCase.duration)
+                result += "| \(testResult) \(time) | \(name) <br>\n"
+            }
+            
+            result += "<br>\n"
+            result += "</details>\n"
+        }
+        
+        let testsRunResult = totalTestsCount == totalSucceedCount ? "✅" : "❌"
+        var testsResult = "# \(testsRunResult) \(totalTestsCount) tests were completed in \(timeString(totalTime))"
+        testsResult += "\n \n"
+        testsResult += "\(totalSucceedCount) tests passed, \(totalFailedCount) test failed.\n"
+        testsResult += "\n----\n"
+        testsResult += result
+        
+        return testsResult
+    }
+    
+    private func timeString(_ sec: Double) -> String {
+        "\(String(format: "%.2f", sec))s"
+    }
+}

--- a/Sources/TestifySDK/Models/OutputFormat.swift
+++ b/Sources/TestifySDK/Models/OutputFormat.swift
@@ -7,8 +7,9 @@
 
 import Foundation
 
-public enum OutputFormat : String  {
+public enum OutputFormat : String, CaseIterable  {
     case json
     case junit
     case md
+    case gfm
 }

--- a/Sources/testify/main.swift
+++ b/Sources/testify/main.swift
@@ -9,12 +9,15 @@ import Foundation
 import TestifySDK
 
 let args = CommandLine.arguments
-var format: String = OutputFormat.json.rawValue
+var outputFormat: OutputFormat = .json
 if (args.count >= 2) {
-    if let enumCase = OutputFormat(rawValue: args[1]) {
-        format = enumCase.rawValue
+    if let format = OutputFormat(rawValue: args[1]) {
+        outputFormat = format
     } else {
-        fatalError("Error: Unknown output format. Available formats: 'json', 'junit', 'md'")
+        let formats = OutputFormat.allCases
+            .map { "'\($0)'"}
+            .joined(separator: ", ")
+        fatalError("Error: Unknown output format. Available formats: \(formats)")
     }
 }
 
@@ -28,23 +31,25 @@ repeat {
 let decoder = RawTestResultDecoder()
 let suite = try decoder.decode(input)
 
-switch format {
-case OutputFormat.json.rawValue:
+switch outputFormat {
+case .json:
     let encoder = JSONEncoder()
     encoder.outputFormatting = .prettyPrinted
     let jsonData = try! encoder.encode(suite)
     print("\n", String(data: jsonData, encoding: .utf8)!, "\n")
     
-case OutputFormat.junit.rawValue:
+case .junit:
     let encoder = TestResultJunitEncoder()
     let junitData = try! encoder.encode(suite)
     print(junitData)
     
-case OutputFormat.md.rawValue:
+case .md:
     let encoder = TestResultMarkdownEncoder()
     let mdData = try! encoder.encode(suite)
     print(mdData)
     
-default:
-    fatalError("Error: Unknown output format")
+case .gfm:
+    let encoder = TestResultGitHubFlavoredMarkdownEncoder()
+    let mdData = try! encoder.encode(suite)
+    print(mdData)
 }


### PR DESCRIPTION
Thank you for your work.
I was able to implement the test run report using your library. 

As I use it for the GitHub Actions workflow, it is more convenient for me to display only the summaries of each test suite.  And utilize the `details` syntax to show the rest information when required.

I added support for gfm format to the tool. The tables are not supported inside the `details` tag, so I switched back to the plain text format in the test suite details.

It might be possible to use HTML table tags because the <br> tag works. I don't investigate it deeply enough.

Please review the PR.

https://user-images.githubusercontent.com/16370048/236441495-6fd553f5-3034-4130-9a34-d7e8d7b7d61d.mp4


